### PR TITLE
change a couple 'pi' specific references to $USER instead.

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,3 @@
-cc /home/pi/Langstone/LangstoneGUI_Pluto.c -o /home/pi/Langstone/GUI_Pluto -liio -llgpio 
-cc /home/pi/Langstone/HW_Test.c -o /home/pi/Langstone/HW_Test -llgpio
-cc /home/pi/Langstone/Pluto_Test.c -o /home/pi/Langstone/Pluto_Test -liio
+cc /home/$USER/Langstone/LangstoneGUI_Pluto.c -o /home/$USER/Langstone/GUI_Pluto -liio -llgpio 
+cc /home/$USER/Langstone/HW_Test.c -o /home/$USER/Langstone/HW_Test -llgpio
+cc /home/$USER/Langstone/Pluto_Test.c -o /home/$USER/Langstone/Pluto_Test -liio

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ sudo rm /etc/profile.d/sshpwd.sh
 if !(grep Langstone ~/.bashrc) then
   echo if test -z \"\$SSH_CLIENT\" >> ~/.bashrc 
   echo then >> ~/.bashrc
-  echo /home/pi/Langstone/run >> ~/.bashrc
+  echo /home/$USER/Langstone/run >> ~/.bashrc
   echo fi >> ~/.bashrc
 fi
 


### PR DESCRIPTION
This should make it easier to install on non-pi users, which the new raspberry pi installer makes very easy to configure a default user with a new name.