### PR TITLE
Add support for PTT using Volume down on a CM108 based sound card

### DIFF
--- a/LangstoneGUI_Pluto.c
+++ b/LangstoneGUI_Pluto.c
@@ -11,6 +11,7 @@
 #include "Graphics.h"
 #include "Touch.h"
 #include "Mouse.h"
+#include "hmi.h"
 #include "Morse.c"
 #include <netdb.h>
 #include <netinet/in.h>                                                                                                      
@@ -39,6 +40,7 @@ void setTxFilter(int low,int high);
 void setBandBits(int b);
 void processTouch();
 void processMouse(int mbut);
+void processHmi(int hm);
 void setRotation(int rot);
 void initGUI();
 void sendFifo(char * s);
@@ -268,9 +270,11 @@ int tuneDigit=8;
 
 char mousePath[30];
 char touchPath[30];
+char hmiPath[30];
 int mousePresent;
 int touchPresent;
 int plutoPresent;
+int hmiPresent;
 int portsdownPresent;
 
 
@@ -352,6 +356,7 @@ int main(int argc, char* argv[])
   if(touchPresent) initTouch(touchPath);
   printf("Initialising Mouse at %s\n",mousePath);
   if(mousePresent) initMouse(mousePath);
+  if(hmiPresent) initHmi(hmiPath);
   initGUI(); 
   initSDR(); 
   //              RGB Vals   Black >  Blue  >  Green  >  Yellow   >   Red     4 gradients    //number of gradients is varaible
@@ -389,7 +394,15 @@ int main(int argc, char* argv[])
            
       }
       
-      
+    if(hmiPresent)
+      {
+        int hr=getHmi();
+        if(hr > 0)
+          {
+          processHmi(hr);
+          }
+      }
+            
    
     if(sendBeacon==2)
       {
@@ -963,11 +976,12 @@ void detectHw()
   size_t len=0;
   ssize_t rd;
   int p;
-  char handler[2][20];
+  char handler[3][20];
   char * found;
   p=0;
   mousePresent=0;
   touchPresent=0;
+  hmiPresent=0;
   portsdownPresent=0;
   fp=fopen("/proc/bus/input/devices","r");
    while ((rd=getline(&ln,&len,fp)!=-1))
@@ -977,8 +991,13 @@ void detectHw()
         p=0;
         if((strstr(ln,"FT5406")!=NULL) || (strstr(ln,"pi-ts")!=NULL) || (strstr(ln,"ft5x06")!=NULL))         //Found Raspberry Pi TouchScreen entry
           {
-           p=1;
-          }                                                                  
+           p=1;                                //we have found the touchscreen
+          }  
+          
+        if(strstr(ln,"C-Media")!=NULL)         //Found HMI device on the CM108 sound card
+          {
+           p=2;                                //hmi device on the sound card
+          }                                                                 
       }
       
       if(ln[0]=='H')        //handlers
@@ -988,19 +1007,28 @@ void detectHw()
            found=strstr(ln,"event");        
            strcpy(handler[p],found); 
            handler[p][strlen(found)-2] = 0;         
-           if(p==0) 
+           if(p==0)                                 //not the touch screen so assume it is a normal mouse
             {
               sprintf(mousePath,"/dev/input/%s",handler[0]);
               mousePresent=1;
               printf("Found Mouse at %s\n",mousePath); 
             }
-           if(p==1) 
+           if(p==1)                                 //touch screen 
            {
              sprintf(touchPath,"/dev/input/%s",handler[1]);
              touchPresent=1;
              printf("Found Touch at %s\n",touchPath);
            }
          }
+         if((strstr(ln,"kbd")!=NULL) && (p==2))             //found the HMI Entry for the CM108 Sound card
+          {
+           found=strstr(ln,"event");        
+           strcpy(handler[p],found); 
+           handler[p][strlen(found)-2] = 0;         
+           sprintf(hmiPath,"/dev/input/%s",handler[2]);
+           hmiPresent=1;
+           printf("Found HMI Device at %s\n",hmiPath); 
+          }       
       }   
     }
   fclose(fp);
@@ -1636,7 +1664,18 @@ popupSel=NONE;
 displayMenu();
 }
 
-                                                           
+void processHmi(int hm)
+{
+  if(hm==1)         //volume down button released
+    {
+      setPtts(0);
+    }
+   if(hm == 2)     //volume down button pressed
+    {
+       setPtts(1);
+    }
+}
+                                                          
 void processMouse(int mbut)
 {
   if(mbut==128)       //scroll whell turned 
@@ -2177,10 +2216,10 @@ void setPtts(int p)
  if(p==1)
  {
   ptts=1;
-  setTx(ptt|ptts);
   gotoXY(funcButtonsX+buttonSpaceX*6,funcButtonsY);
   setForeColour(255,0,0);
   displayButton("PTT"); 
+  setTx(ptt|ptts);
  }
   else
  {

--- a/hmi.h
+++ b/hmi.h
@@ -1,0 +1,65 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/select.h>
+#include <signal.h>
+#include <linux/input.h>
+
+int hfd;
+
+int hmiAvailable();
+int getHmi();
+int initHmi(char * hpath);
+
+
+int initHmi(char * hpath)
+{
+        if ((hfd = open(hpath, O_RDONLY)) < 0) 
+        {
+                printf("HMI Open failed\n");
+                return 1;
+        }
+        else
+        {
+                printf("HMI Open OK\n");
+                return 0;
+        }
+}
+
+//Returns 0 if no HMI Input available 1 if Volume Down is pressed
+
+int getHmi()
+{
+  int i;
+  size_t rb;
+  struct input_event ev[64];
+  int retval;
+  
+  retval=0;
+  if(hmiAvailable())
+    {
+    rb=read(hfd,ev,sizeof(struct input_event)*64);
+        for (i = 0;  i <  (rb / sizeof(struct input_event)); i++)
+        {
+          if((ev[i].type == 1) && (ev[i].code == 114))                       //volume down button
+           {
+              retval = ev[i].value + 1;                                      //1 = released 2 = pressed
+           }
+	    }
+    }
+  return retval;
+
+}
+
+
+int hmiAvailable()  
+{
+  struct timeval tv;
+  fd_set fds;
+  tv.tv_sec = 0;
+  tv.tv_usec = 0;
+  FD_ZERO(&fds);
+  FD_SET(hfd, &fds);
+  select(hfd+1, &fds, NULL, NULL, &tv);
+  return (FD_ISSET(hfd, &fds));
+}

--- a/installHack.sh
+++ b/installHack.sh
@@ -107,6 +107,7 @@ cp stop_hack stop
 if !(grep Langstone ~/.bashrc) then
   echo if test -z \"\$SSH_CLIENT\" >> ~/.bashrc 
   echo then >> ~/.bashrc
+  echo "stty -echo -icanon" >> ~/.bashrc
   echo /home/pi/Langstone/run >> ~/.bashrc
   echo fi >> ~/.bashrc
 fi

--- a/installPluto.sh
+++ b/installPluto.sh
@@ -105,6 +105,7 @@ cp stop_pluto stop
 if !(grep Langstone ~/.bashrc) then
   echo if test -z \"\$SSH_CLIENT\" >> ~/.bashrc 
   echo then >> ~/.bashrc
+  echo "stty -echo -icanon" >> ~/.bashrc
   echo /home/pi/Langstone/run >> ~/.bashrc
   echo fi >> ~/.bashrc
 fi


### PR DESCRIPTION
Allows the volume down button on a CM108 based sound device to act as a PTT. 