### PR TITLE
User HOME directory impairment of fopen() and Debian Trixie

### DIFF
--- a/Screen_Message.c
+++ b/Screen_Message.c
@@ -1,5 +1,6 @@
 #include "Graphics.h"
 
+#define MAX_FILENAME_LENGTH 255
 
 int screenrotate = 0;
 int V2Display =0 ;
@@ -8,6 +9,7 @@ int V2Display =0 ;
 void showMessage(char * msg);
 void setRotation(int rot);
 int readConfig(void);
+FILE *openFile( char *fn );
 
 int main(int argc, char* argv[])
 {
@@ -37,32 +39,64 @@ void setRotation(int rot)
   rotateScreen(rot);
 }
 
+
 int readConfig(void)
 {
-FILE * conffile;
-char variable[50];
-char value[100];
-char vname[20];
+    FILE * conffile;
+    char variable[50];
+    char value[100];
+    char vname[20];
 
-conffile=fopen("$HOME/Langstone/Langstone_Pluto.conf","r");
+    conffile = openFile("Langstone/Langstone_Pluto.conf");
+    if( conffile == NULL )
+    {
+        conffile = openFile("Langstone/Langstone_Hack.conf");
+        if(conffile == NULL )
+            return -1;
+    }
 
-if(conffile==NULL)
-  {
-    conffile=fopen("$HOME/Langstone/Langstone_Hack.conf","r");
-  }
-  
-if(conffile==NULL)
-  {
-    return -1;
-  }
+    while (fscanf(conffile, "%49s %99s [^\n]\n", variable, value) !=EOF)
+    {
+        if (strstr(variable, "RotateScreen"))
+            sscanf(value, "%d", &screenrotate);
+    }
 
-while(fscanf(conffile,"%49s %99s [^\n]\n",variable,value) !=EOF)
-  {
-     
-    if(strstr(variable,"RotateScreen")) sscanf(value,"%d",&screenrotate);            
-  }
+    fclose(conffile);
+    return 0;
+}
 
-fclose(conffile);
-return 0;
 
+FILE *openFile(char *fn)
+{
+    char filename[MAX_FILENAME_LENGTH] = {0};
+    int fnlen = 0;
+
+    /* find user path i.e. /home/pi */
+    char *userpath = getenv("HOME");
+    if (userpath == NULL)
+    {
+        printf("Can read $HOME env variable");      // TODO: Move to separate logfile
+        return NULL;
+    }
+
+    /* allocate space for filename */
+    fnlen = snprintf(NULL, 0, "%s/%s", userpath, fn);
+    if (fnlen > MAX_FILENAME_LENGTH)
+    {
+        printf("Filename greater than %i characters\n", MAX_FILENAME_LENGTH);       // TODO: Move to separate logfile
+        return NULL;
+    }
+
+    memset(filename, 0, MAX_FILENAME_LENGTH);       // trust no one
+
+    /* put it all together */
+    int retval = snprintf(filename, MAX_FILENAME_LENGTH, "%s/%s", userpath, fn);
+    if (retval != fnlen)
+    {
+        printf("Can't generate filename correctly, ignored\n");     // TODO: Move to separate logfile
+        return NULL;
+    }
+
+    /* try to get file handle */
+    return fopen(filename,"r");
 }


### PR DESCRIPTION
In the latest Raspberry Pi- 5 OS (Debian Trixie) the function fopen() does not appear to handle $HOME in the path name.  This unfortunately broke reading and writing of the config files, symptom was loss of screen rotation.

I've added a new function openFile() to the Screen_Message and both GUI's that uses the getenv() function to get the user path from the HOME environmental variable and prepend it to the filename passed to fopen().   The printf() calls when things fail within the openFile() function would be better suited to a logging function, but can be looked at later.

Has been tested working on rPi-5 and Pluto, I don't have Hack RF to test the GUI_Hack but code changes were the same assumed working.

Hope this helps.